### PR TITLE
improve build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,27 +7,32 @@ RELEASE?=0.0.3
 
 COMMIT?=$(shell git rev-parse --short HEAD)
 BUILD_TIME?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
+CURDIR?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 GOOS?=linux
 GOARCH?=amd64
 
-container:
-	docker build -t $(CONTAINER_IMAGE):$(RELEASE) .
+# Should only ever need to be run once
+push-dev:
+	docker build -f ./deployment/Dockerfile-dev -t $(CONTAINER_IMAGE):latest-dev .
+	docker push $(CONTAINER_IMAGE):latest-dev
 
-run: container
-	docker stop $(APP):$(RELEASE) || true && docker rm $(APP):$(RELEASE) || true
-	docker run --name ${APP} -p ${PORT}:${PORT} --rm \
-		-e "PORT=${PORT}" \
-		$(APP):$(RELEASE)
+push-staging:
+	docker build -f ./deployment/Dockerfile-staging -t $(CONTAINER_IMAGE):$(RELEASE)-staging .
+	docker push $(CONTAINER_IMAGE):$(RELEASE)-staging
 
-push: container
-	docker push $(CONTAINER_IMAGE):$(RELEASE)
-
-local: push
+local:
 	helm upgrade --install dev-${APP} ./chart/kubert
 
 remove:
 	helm delete dev-${APP}
+
+stop:
+	minikube stop
+
+start:
+
+	minikube start --mount-string ${CURDIR}:${CURDIR} --mount
 
 test:
 	go test -v -race ./...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PORT?=8080
 PROJECT?=github.com/bmsandoval/kubert
 CONTAINER_IMAGE?=docker.io/bmsandoval/${APP}
 
-RELEASE?=0.0.2
+RELEASE?=0.0.3
 
 COMMIT?=$(shell git rev-parse --short HEAD)
 BUILD_TIME?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
@@ -11,16 +11,7 @@ BUILD_TIME?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 GOOS?=linux
 GOARCH?=amd64
 
-clean:
-	rm -f ${APP}
-
-compile: clean
-	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build \
-		-ldflags "-s -w -X ${PROJECT}/version.Release=${RELEASE} \
-		-X ${PROJECT}/version.Commit=${COMMIT} -X ${PROJECT}/version.BuildTime=${BUILD_TIME}" \
-		-o ${APP}
-
-container: compile
+container:
 	docker build -t $(CONTAINER_IMAGE):$(RELEASE) .
 
 run: container
@@ -32,7 +23,7 @@ run: container
 push: container
 	docker push $(CONTAINER_IMAGE):$(RELEASE)
 
-minikube: push
+local: push
 	helm upgrade --install dev-${APP} ./chart/kubert
 
 remove:

--- a/README.md
+++ b/README.md
@@ -1,174 +1,19 @@
-# Express.js Docker example
-
-Example to show how to build a microservice with Node.js and Express.js with instructions for: Kubernetes with YAML, [OpenFaaS](https://github.com/openfaas/faas), Docker and running locally with `node`
-
-## Clone the repository
-
-```
-git clone https://github.com/alexellis/expressjs-docker \
-&& cd expressjs-docker
-```
-
-## Endpoints
-
-* `/` - serves a HTML page
-* `/links` - serves a JSON response of links
-* `/health` - serves a health endpoint giving 200 OK
-
-## Try it with Kubernetes
-
-You can first try running the example with Kubernetes, then try it with OpenFaaS to compare the experience. OpenFaaS also adds optional templates and an API to remove boilerplate coding: "look ma', (almost) no YAML!"
-
-```sh
-kubectl apply -f ./yaml
-kubectl port-forward deploy/expressjs 8080:8080 &
-
-curl 127.0.0.1:8080
-```
-
-Conservative resource limits / requests values have been set in the YAML files:
-
-```yaml
-        resources:
-          limits:
-            cpu: 10m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 128Mi
-```
-
-Clean up:
-
-```sh
-kubectl delete -f ./yaml
-```
-
-See also: [/yaml](./yaml) - (optional) - YAML files to deploy to Kubernetes directly
-
-## Run it with [OpenFaaS](https://github.com/openfaas/faas)
-
-Watch [my latest video on OpenFaaS with the PLONK Stack](https://skillsmatter.com/skillscasts/14268-serverless-2-0-get-started-with-the-plonk-stack?utm_medium=social&utm_source=twitter&utm_campaign=bafdbc&utm_content=skillscast), which is made up of Prometheus, Linkerd (optional), OpenFaaS, NATS, and Kubernetes.
-
-If you don't already have OpenFaaS, then:
-
-* [Install faas-cli](https://docs.openfaas.com/cli/install/)
-* [Install OpenFaaS](https://docs.openfaas.com/deployment/)
-
-Deploy:
-
-```sh
-faas-cli deploy
-```
-
-Access using the gateway's URL found via `faas-cli describe service`
-
-Edit/rebuild:
-
-Edit `image: alexellis2` and replace with your own Docker Hub username in `stack.yml`, then run:
-
-```sh
-faas-cli up
-```
-
-Cleaning up:
-
-```
-faas-cli rm
-```
-
-See also: [stack.yml](./stack.yml) - (optional) - OpenFaaS deployment file
-
-### OpenFaaS Templates
-
-With OpenFaaS Templates you don't need to bother with managing Dockerfiles and TCP-port bindings, unless you like that sort of thing, then you can do that too just like we did in this example.
-
-* [Microservice for Node.js with express visible](https://github.com/openfaas-incubator/node10-express-service/)
-* [Function for Node.js with express hidden](https://github.com/openfaas-incubator/node10-express-service/)
-* [Legacy Node template without express](https://github.com/openfaas/templates/tree/master/template/node)
-
-Try one of the templates above:
-
-```
-faas-cli template store list
-
-faas-cli template store pull node10-express
-
-faas-cli new --lang node10-express express-fn
-```
-
-Then edit `express-fn/hander.js` and `express-fn.yml`, before then running:
-
-```
-faas-cli up -f express-fn.yml
-```
-
-What is different?
-
-* No Kubernetes YAML files to manage
-* No Dockerfile to worry about
-* No index.js, no port-bindings, no Prometheus metrics to add, and no auto-scaling rules. OpenFaaS automates all of this and more.
-
-## Run it with docker
-
-```sh
-docker run --name expressjs -p 8081:8080 -ti alexellis2/service:0.3.2
-```
-
-Access via http://localhost:8081
-
-Clean up:
-
-```
-docker rm -f expressjs
-```
-
-## Run it without Docker, locally
-
-* [Install Node.js](https://nodejs.org/en/)
-
-```sh
-npm install
-
-http_port=3000 node index.js
-```
-
-Access via http://localhost:3000
-
-Clean up by hitting Control + C.
-
-## Install via Helm 3
-
-First install [Helm 3](https://helm.sh).
-
-```
-helm repo add kubert https://alexellis.github.io/kubert/
-
-helm repo update
-
-helm install kubert-tester kubert/kubert
-```
-
-## The parts
-
-* [Dockerfile](./Dockerfile)
-
-* [index.js](./index.js) - the entry-point for Express.js
-
-* [stack.yml](./stack.yml) - (optional) - OpenFaaS deployment file
-
-* [/yaml](./yaml) - (optional) - YAML files to deploy to Kubernetes directly
-
-Other links:
-
-* [Express.js docs](https://expressjs.com)
-
-* [OpenFaaS docs](https://www.openfaas.com/)
-
-## Contributing via GitHub
-
-Before contributing code, please see the [CONTRIBUTING guide](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md). This repo uses the same guide as [inlets.dev](https://inlets.dev/).
-
-Both Issues and PRs have their own templates. Please fill out the whole template.
-
-All commits must be signed-off as part of the [Developer Certificate of Origin (DCO)](https://developercertificate.org)
+Setup:
+edit .../kubert/chart/kubert/values.yaml and point it to the directory of this project
+$ make start
+$ make local
+follow the instruction to forward port
+hit it with postman, should be good
+
+
+Software and Versions:
+MINIKUBE version: v1.6.2
+
+KUBERNETES versions:
+Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"darwin
+/amd64"}
+Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-07T21:12:17Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/a
+md64"}
+
+HELM version:
+version.BuildInfo{Version:"v3.0.2", GitCommit:"19e47ee3283ae98139d98460de796c1be1e3975f", GitTreeState:"clean", GoVersion:"go1.13.5"}

--- a/chart/kubert/Chart.yaml
+++ b/chart/kubert/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/chart/kubert/templates/deployment.yaml
+++ b/chart/kubert/templates/deployment.yaml
@@ -25,20 +25,40 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{.Values.registry}}/{{.Chart.Name}}:{{.Chart.Version}}"
+          image: "{{.Values.registry}}/{{.Chart.Name}}:latest-dev"
           imagePullPolicy: {{ .Values.pullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              cd /src
+              CompileDaemon -log-prefix=false -build="go build -v -mod vendor -o ../app/main ." -command="../app/main"
+          volumeMounts:
+            - mountPath: /src
+              name: go-source
+            - mountPath: /app
+              name: go-app
+            - mountPath: /cache
+              name: go-cache
+            - mountPath: /tmp
+              name: go-build
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http
+          env:
+            - name: PORT
+              value: "8080"
+            - name: GOCACHE
+              value: /cache
+{{/*          livenessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /health*/}}
+{{/*              port: http*/}}
+{{/*          readinessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /ready*/}}
+{{/*              port: http*/}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -53,3 +73,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+        - name: go-source
+          hostPath:
+            path: {{ .Values.Kubert.Volumes.GoSource }}
+        - name: go-cache
+          emptyDir: {}
+        - name: go-app
+          emptyDir: {}
+        - name: go-build
+          emptyDir: {}
+

--- a/chart/kubert/values.yaml
+++ b/chart/kubert/values.yaml
@@ -2,9 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+Kubert:
+  Image: kubert
+  ImageTag: latest-dev
+  Volumes:
+    GoSource: /Users/bryansandoval/projects/kubert
+
 replicaCount: 1
 
-pullPolicy: Always
+pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/chart/kubert/values.yaml
+++ b/chart/kubert/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 1
 
-pullPolicy: IfNotPresent
+pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deployment/Dockerfile-dev
+++ b/deployment/Dockerfile-dev
@@ -1,0 +1,17 @@
+# Dockerfile References: https://docs.docker.com/engine/reference/builder/
+# pulled from https://www.callicoder.com/deploy-containerized-go-app-kubernetes/
+
+# Start from the latest golang base image
+FROM golang:1.13 as builder
+
+# Add Maintainer Info
+LABEL maintainer="Bryan Sandoval <bmsandoval@gmail.com>"
+
+WORKDIR /app
+
+RUN go get github.com/githubnemo/CompileDaemon
+
+## This container exposes port 8080 to the outside world
+EXPOSE 8080
+
+#ENTRYPOINT CompileDaemon -log-prefix=false -build="go build -v -mod vendor -o main ./" -command="./main"

--- a/deployment/Dockerfile-staging
+++ b/deployment/Dockerfile-staging
@@ -8,7 +8,7 @@ FROM golang:1.13 as builder
 LABEL maintainer="Bryan Sandoval <bmsandoval@gmail.com>"
 
 # Set the Current Working Directory inside the container
-WORKDIR /app
+WORKDIR /src
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
@@ -28,10 +28,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 #RUN apk --no-cache add ca-certificates
 FROM scratch
 
-WORKDIR /root/
+WORKDIR /app/
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=builder /app/main .
+COPY --from=builder /src/main .
 
 # Expose port 8080 to the outside world
 ENV PORT 8080

--- a/handlers/home.go
+++ b/handlers/home.go
@@ -6,5 +6,5 @@ import (
 
 // home is a simple HTTP handler function which writes a response.
 func home(w http.ResponseWriter, _ *http.Request) {
-	w.Write([]byte("your mom went to college"))
+	w.Write([]byte("Your mom went to college"))
 }


### PR DESCRIPTION
Running the app currently requires building locally, putting the image inside a container, pushing an image of that container to docker and pulling it into Kubernetes.

What I'd like to happen in this PR:
1) We should have a consistent environment for building the app, so let's put that in a static docker container
2) We shouldn't be pushing up to docker constantly. Let's update kubernetes so it can build the app inside the container as the source code changes